### PR TITLE
multi-screen compatibility for wayland

### DIFF
--- a/hwcomposer/hwcomposer.cpp
+++ b/hwcomposer/hwcomposer.cpp
@@ -48,6 +48,7 @@
 #include "extension.h"
 #include "OpenfdeWindow.h"
 #include "egl-tools.h"
+#include "xdg-shell-client-protocol.h"
 
 using ::android::hardware::configureRpcThreadpool;
 using ::android::hardware::joinRpcThreadpool;
@@ -343,6 +344,7 @@ static void setup_viewport_destination(wp_viewport *viewport, hwc_rect_t frame, 
     wp_viewport_set_destination(viewport,
             fmax(1, ceil((frame.right - frame.left) / display->scale)),
             fmax(1, ceil((frame.bottom - frame.top) / display->scale)));
+    ALOGW("setup_viewport_destination display->scale: %f", display->scale);
 }
 
 static struct wl_surface *get_surface(struct openfde_hwc_composer_device_1 *pdev, hwc_layer_1_t *layer, struct window *window, bool multi)
@@ -352,9 +354,22 @@ static struct wl_surface *get_surface(struct openfde_hwc_composer_device_1 *pdev
         pdev->display->layers[window->surface] = {
             .x = layer->displayFrame.left,
             .y = layer->displayFrame.top };
-        if (!multi && pdev->display->scale != 1 && pdev->display->viewporter && !window->viewport) {
-            window->viewport = wp_viewporter_get_viewport(pdev->display->viewporter, window->surface);
+        if ((!multi && pdev->display->scale != 1 && pdev->display->viewporter && !window->viewport) || pdev->display->preferred_scale) {
+            ALOGW("get_surface multi: %d, pdev->display->scale: %f, ", multi, pdev->display->scale);
+            if(pdev->display->preferred_scale){
+                pdev->display->preferred_scale = false;
+            }
+            if(!window->viewport){
+                window->viewport = wp_viewporter_get_viewport(pdev->display->viewporter, window->surface);
+            }
             setup_viewport_destination(window->viewport, layer->displayFrame, pdev->display);
+            if(window->bg_viewport){
+                wp_viewport_set_destination(window->bg_viewport, pdev->display->full_width/pdev->display->scale, pdev->display->height/pdev->display->scale);
+                wl_surface_commit(window->bg_surface);
+            }
+            if(pdev->display->primary){
+                xdg_toplevel_set_fullscreen(window->xdg_toplevel, pdev->display->primary->wl_output);
+            }
         }
         return window->surface;
     }

--- a/hwcomposer/hwcomposer.cpp
+++ b/hwcomposer/hwcomposer.cpp
@@ -107,6 +107,10 @@ static bool update_cursor_surface(openfde_hwc_composer_device_1* pdev, hwc_layer
     }
 
     fb_layer->compositionType = HWC_OVERLAY; // Not participating in SurfaceFlinger GPU compositing hide internal cursor
+    std::scoped_lock lock(pdev->display->cursorMutex);
+    if(!pdev->display->pointer){
+        return false;
+    }
 
     /*
      * To update the wayland cursor, the fde.mouse_icon_addr system property was introduced.
@@ -199,7 +203,10 @@ static int hwc_prepare(hwc_composer_device_1_t* dev,
         foundCursorLayer |= update_cursor_surface(pdev, &contents->hwLayers[i], i);
     }
     if(!foundCursorLayer && pdev->display->mouse_icon_addr != -1){
-        wl_pointer_set_cursor(pdev->display->pointer, pdev->display->serial, NULL, 0, 0);
+        std::scoped_lock lock(pdev->display->cursorMutex);
+        if(pdev->display->pointer){
+            wl_pointer_set_cursor(pdev->display->pointer, pdev->display->serial, NULL, 0, 0);
+        }
         pdev->display->mouse_icon_addr = -1;
         ALOGI("wayland cursor hidden");
     }

--- a/hwcomposer/wayland-hwc.cpp
+++ b/hwcomposer/wayland-hwc.cpp
@@ -75,6 +75,8 @@
 #include "fractional-scale-v1-client-protocol.h"
 #include <pointer-gestures-unstable-v1-client-protocol.h>
 
+#include "xdg-output-unstable-v1-client-protocol.h"
+
 using ::android::hardware::hidl_string;
 
 const int AXIS_TOUCH_SLOT_ID = 8;
@@ -93,6 +95,77 @@ static int gesture_scaling_stride;
 struct buffer;
 static void handle_pinch_update(void *data, struct zwp_pointer_gesture_pinch_v1 *gesture, uint32_t time, wl_fixed_t dx, wl_fixed_t dy, wl_fixed_t scale, wl_fixed_t rotation);
 static void handle_pinch_end(void *data, struct zwp_pointer_gesture_pinch_v1 *gesture, uint32_t serial, uint32_t time, int cancelled);
+
+static void find_primary(struct display *d) {
+    d->primary = NULL;
+    for (int i = 0; i < d->num_outputs; i++) {
+        struct output *out = &d->outputs[i];
+        if (out->done && (out->logical_x == 0 || out->logical_y == 0)) {
+            d->primary = out;
+            ALOGW("find_primary success");
+            return;
+        }
+    }
+    if (d->num_outputs > 0) {
+        for (int i = 0; i < d->num_outputs; i++) {
+            struct output *out = &d->outputs[i];
+            if (out->done && out->pixel_width != 0 && out->pixel_width != 0 && out->scale != 0) {
+                d->primary = out;
+                ALOGW("find_primary use default %d", i);
+                return;
+            }
+        }
+    }
+}
+
+
+static void xdg_output_logical_position(void *data, struct zxdg_output_v1 *xdg_output,
+                                        int32_t x, int32_t y) {
+    ALOGW("xdg_output_logical_position logical_x: %d, logical_y: %d", x, y);
+    struct output *out = (struct output *)data;
+    out->logical_x = x;
+    out->logical_y = y;
+}
+
+static void xdg_output_logical_size(void *data, struct zxdg_output_v1 *xdg_output,
+                                    int32_t width, int32_t height) {
+    ALOGW("xdg_output_logical_size logical_width: %d, logical_height: %d", width, height);
+    struct output *out = (struct output *)data;
+    out->logical_width = width;
+    out->logical_height = height;
+}
+
+static void xdg_output_done(void *data, struct zxdg_output_v1 *xdg_output) {
+    ALOGW("xdg_output_done");
+    (void)xdg_output;
+    struct output *out = (struct output *)data;
+    out->done = 1;
+}
+
+static void xdg_output_name(void *data, struct zxdg_output_v1 *xdg_output,
+                            const char *name) {
+    ALOGW("xdg_output_name");
+    struct output *out = (struct output *)data;
+        if (name) out->name = strdup(name);
+
+}
+
+static void xdg_output_description(void *data, struct zxdg_output_v1 *xdg_output,
+                                   const char *description) {
+    ALOGW("xdg_output_description");
+    struct output *out = (struct output *)data;
+    if (description) out->description = strdup(description);
+}
+
+
+static const struct zxdg_output_v1_listener xdg_output_listener = {
+    .logical_position = xdg_output_logical_position,
+    .logical_size     = xdg_output_logical_size,
+    .done             = xdg_output_done,
+    .name             = xdg_output_name,
+    .description      = xdg_output_description
+};
+
 
 void
 destroy_buffer(struct buffer* buf) {
@@ -396,6 +469,7 @@ xdg_toplevel_handle_configure(void *data, struct xdg_toplevel *,
                               int32_t width, int32_t height,
                               struct wl_array *)
 {
+    ALOGW("xdg_toplevel_handle_configure: width: %d, height: %d",width, height);
     struct window *window = (struct window *)data;
     struct display *display = window->display;
 
@@ -480,6 +554,10 @@ void
 destroy_window(struct window *window, bool keep)
 {
     if (window->isActive) {
+        if (window->fractional_scale) {
+            wp_fractional_scale_v1_destroy(window->fractional_scale);
+            window->fractional_scale = NULL;
+        }
         if (window->callback)
             wl_callback_destroy(window->callback);
 
@@ -519,6 +597,7 @@ destroy_window(struct window *window, bool keep)
 
 static void fractional_scale_handle_preferred_scale(void *data, struct wp_fractional_scale_v1 *,
             uint32_t scale_times_120) {
+    ALOGW("fractional_scale_handle_preferred_scale scale_times_120: %d", scale_times_120);
     struct display *display = (struct display *)data;
     if (!display->viewporter) {
         // We should always have the viewporter if we have the fractional scale manager
@@ -526,6 +605,9 @@ static void fractional_scale_handle_preferred_scale(void *data, struct wp_fracti
         return;
     }
     display->scale = scale_times_120 / 120.0;
+    ALOGW("fractional_scale_handle_preferred_scale display->scale: %f", display->scale);
+    display->preferred_scale = true;
+
 }
 
 static const struct wp_fractional_scale_v1_listener fractional_scale_listener = {
@@ -572,6 +654,13 @@ create_window(struct display *display, bool use_subsurfaces, std::string appID, 
                                       { xdg_toplevel_set_title(window->xdg_toplevel, value.c_str()); });
         else
             xdg_toplevel_set_title(window->xdg_toplevel, appID.c_str());
+        if(!display->multi_windows){
+            if(display->primary){
+                xdg_toplevel_set_fullscreen(window->xdg_toplevel, display->primary->wl_output);
+            }else{
+                xdg_toplevel_set_fullscreen(window->xdg_toplevel, NULL);
+            }
+        }
 
         if (appID != "Openfde")
             appID = "openfde." + appID;
@@ -600,11 +689,10 @@ create_window(struct display *display, bool use_subsurfaces, std::string appID, 
 
     if (calibrating && display->fractional_scale_manager) {
         // We only support one global scale
-        wp_fractional_scale_v1* fs = wp_fractional_scale_manager_v1_get_fractional_scale(
+        window->fractional_scale = wp_fractional_scale_manager_v1_get_fractional_scale(
                 display->fractional_scale_manager, window->surface);
-        wp_fractional_scale_v1_add_listener(fs, &fractional_scale_listener, display);
+        wp_fractional_scale_v1_add_listener(window->fractional_scale, &fractional_scale_listener, display);
         wl_display_roundtrip(display->display);
-        wp_fractional_scale_v1_destroy(fs);
     }
     finished_computing_scale(display);
 
@@ -1840,9 +1928,9 @@ seat_handle_capabilities(void *data, struct wl_seat *seat, uint32_t wl_caps)
         wl_touch_set_user_data(d->touch, d);
         wl_touch_add_listener(d->touch, &touch_listener, d);
     } else if (!(caps & WL_SEAT_CAPABILITY_TOUCH) && d->touch) {
-        remove(INPUT_PIPE_NAME[INPUT_TOUCH]);
-        wl_touch_destroy(d->touch);
-        d->touch = NULL;
+        //remove(INPUT_PIPE_NAME[INPUT_TOUCH]);
+        //wl_touch_destroy(d->touch);
+        //d->touch = NULL;
     }
 }
 
@@ -1897,40 +1985,64 @@ static const struct zwp_linux_dmabuf_v1_listener dmabuf_listener = {
 
 static void
 output_handle_mode(void *data, struct wl_output *,
-                   uint32_t, int32_t width, int32_t height,
+                   uint32_t flags, int32_t width, int32_t height,
                    int32_t refresh)
 {
-    struct display *d = (struct display *)data;
+    ALOGW("output_handle_mode width: %d, height: %d, refresh: %d", width, height, refresh);
+    struct output *out = (struct output *)data;
+    if (flags & WL_OUTPUT_MODE_CURRENT) {
+        out->pixel_width  = width;
+        out->pixel_height = height;
+        out->refresh = refresh;
+    }
+
+    /*struct display *d = (struct display *)data;
     d->refresh = std::max(d->refresh, refresh);
 
     // Fallback size
     // We can't do anything meaningful if there's more than one display, just pick one at random
     // Hopefully these won't need to be used
     d->full_width = width;
-    d->full_height = height;
+    d->full_height = height;*/
 }
 
 static void
-output_handle_geometry(void *, struct wl_output *,
-               int32_t, int32_t,
-               int32_t, int32_t,
-               int32_t,
-               const char *, const char *,
-               int32_t)
+output_handle_geometry(void *data, struct wl_output *,
+                int32_t x,
+                int32_t y,
+                int32_t physical_width,
+                int32_t physical_height,
+                int32_t subpixel,
+                const char *make,
+                const char *model,
+                int32_t transform)
 {
+    ALOGW("Physical output: %s %s at %d,%d (phys: %dx%d mm)\n",
+           make, model, x, y, physical_width, physical_height);
+    struct output *out = (struct output *)data;
+    out->phys_width_mm  = physical_width;
+    out->phys_height_mm = physical_height;
 }
 
 static void
-output_handle_done(void *, struct wl_output *)
+output_handle_done(void *data, struct wl_output *)
 {
+    ALOGW("output_handle_done");
+
+    struct output *out = (struct output *)data;
+    out->done = 1;
+
 }
 
 static void
 output_handle_scale(void *data, struct wl_output *,
             int32_t scale)
 {
-    struct display *d = (struct display*)data;
-    d->scale = std::max((int)d->scale, scale);
+    ALOGW("output_handle_scale scale: %d", scale);
+    struct output *out = (struct output *)data;
+    out->scale = scale;
+    /*struct display *d = (struct display*)data;
+    d->scale = std::max((int)d->scale, scale);*/
 }
 
 static const struct wl_output_listener output_listener = {
@@ -2362,12 +2474,28 @@ registry_handle_global(void *data, struct wl_registry *registry,
     } else if (strcmp(interface, "wl_shm") == 0) {
 		d->shm = (struct wl_shm *)wl_registry_bind(registry, id,
                 &wl_shm_interface, 1);
-    } else if (strcmp(interface, "wl_output") == 0) {
-        d->output = (struct wl_output*)wl_registry_bind(registry, id,
-                &wl_output_interface, std::min(version, 3U));
-        wl_output_add_listener(d->output, &output_listener, d);
-        wl_display_roundtrip(d->display);
-    } else if (strcmp(interface, "wp_presentation") == 0) {
+    } else if (strcmp(interface, "wl_output") == 0  && d->num_outputs < MAX_OUTPUTS) {
+        ALOGE("wl_output version: %d",version);
+        struct output *out = &d->outputs[d->num_outputs++];
+        out->wl_output = (struct wl_output*)wl_registry_bind(registry, id, &wl_output_interface, std::min(version, 3U));
+        wl_output_add_listener(out->wl_output, &output_listener, out);
+
+        if (d->xdg_output_manager) {
+            out->xdg_output = zxdg_output_manager_v1_get_xdg_output(d->xdg_output_manager, out->wl_output);
+            zxdg_output_v1_add_listener(out->xdg_output, &xdg_output_listener, out);
+        }
+    } else if (strcmp(interface, "zxdg_output_manager_v1") == 0) {
+        ALOGE("zxdg_output_manager_v1 version: %d", version);
+        d->xdg_output_manager = (struct zxdg_output_manager_v1 *)wl_registry_bind(registry, id, &zxdg_output_manager_v1_interface, std::min(version, 3U));
+
+        for (int i = 0; i < d->num_outputs; i++) {
+            struct output *out = &d->outputs[i];
+            if (out->wl_output && !out->xdg_output) {
+                out->xdg_output = zxdg_output_manager_v1_get_xdg_output(d->xdg_output_manager, out->wl_output);
+                zxdg_output_v1_add_listener(out->xdg_output, &xdg_output_listener, out);
+            }
+        }
+    }else if (strcmp(interface, "wp_presentation") == 0) {
         bool no_presentation = property_get_bool("persist.openfde.no_presentation", false);
         if (!no_presentation) {
             d->presentation = (struct wp_presentation*)wl_registry_bind(registry, id,
@@ -2465,6 +2593,7 @@ create_display(const char *gralloc)
     display->refresh = 0;
     display->isMaximized = true;
     display->display = wl_display_connect(NULL);
+    display->multi_windows = property_get_bool("persist.openfde.multi_windows", false);
     ALOGI("WAYLAND_DISPLAY: %s", getenv("WAYLAND_DISPLAY"));
     ALOGI("XDG_RUNTIME_DIR: %s", getenv("XDG_RUNTIME_DIR"));
     if (!display->display) {
@@ -2481,6 +2610,46 @@ create_display(const char *gralloc)
     wl_registry_add_listener(display->registry,
                  &registry_listener, display);
     wl_display_roundtrip(display->display);
+    wl_display_roundtrip(display->display);
+
+    find_primary(display);
+
+    if (display->primary) {
+        ALOGW("Detected primary screen (logical position 0,0):\n");
+        ALOGW("  Current pixel resolution (physical pixels): %d × %d\n", display->primary->pixel_width, display->primary->pixel_height);
+        display->full_width = display->primary->pixel_width;
+        display->full_height = display->primary->pixel_height;
+        ALOGW("  Logical resolution (scaled): %d × %d\n", display->primary->logical_width, display->primary->logical_height);
+	    double scale = ((double)display->primary->pixel_width) / display->primary->logical_width;
+        ALOGW("  scaling factor: %d\n", display->primary->scale);
+        ALOGW("  Floating-point scaling factor: %f\n", scale);
+        ALOGW("  Physical dimensions (mm): %d mm × %d mm\n", display->primary->phys_width_mm, display->primary->phys_height_mm);
+        if (display->primary->phys_width_mm > 0 && display->primary->pixel_width > 0) {
+            double dpi_x = (double)display->primary->pixel_width / (display->primary->phys_width_mm / 25.4);
+            ALOGW("  Estimate horizontal DPI (based on physical pixels): %.1f\n", dpi_x);
+        }
+        if (display->primary->name)        ALOGW("  name: %s", display->primary->name);
+        if (display->primary->description) ALOGW("  description: %s", display->primary->description);
+    } else {
+        ALOGE("Output not found for logical (0,0)");
+        if (display->num_outputs > 0) {
+            ALOGW("Use the first output as the fallback:");
+            ALOGW("  Current pixel resolution: %d × %d", display->outputs[0].pixel_width, display->outputs[0].pixel_height);
+            ALOGW("  Logical resolution: %d × %d", display->outputs[0].logical_width, display->outputs[0].logical_height);
+            ALOGW("  scaling factor: %d", display->outputs[0].scale);
+            display->full_width = display->outputs[0].pixel_width;
+            display->full_height = display->outputs[0].pixel_height;
+        }
+    }
+    if(display->fractional_scale_manager || display->scale == 0){
+        display->scale = 1.0;
+    }
+    if(display->full_width == 0){
+        display->full_width = 1920;
+    }
+    if(display->full_height == 0){
+        display->full_height = 1080;
+    }
 
     display->task = IOpenfdeTask::getService();
     display->isTouchDown = false;

--- a/hwcomposer/wayland-hwc.cpp
+++ b/hwcomposer/wayland-hwc.cpp
@@ -1902,8 +1902,11 @@ seat_handle_capabilities(void *data, struct wl_seat *seat, uint32_t wl_caps)
         chown(INPUT_PIPE_NAME[INPUT_TOUCH], 1000, 1000);
     } else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && d->pointer) {
         remove(INPUT_PIPE_NAME[INPUT_POINTER]);
-        wl_pointer_destroy(d->pointer);
-        d->pointer = NULL;
+        {
+            std::scoped_lock lock(d->cursorMutex);
+            wl_pointer_destroy(d->pointer);
+            d->pointer = NULL;
+        }
     }
 
     if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && !d->keyboard) {

--- a/hwcomposer/wayland-hwc.h
+++ b/hwcomposer/wayland-hwc.h
@@ -56,6 +56,9 @@
 
 #include <functional>
 
+#define MAX_OUTPUTS 16
+
+
 using ::android::sp;
 using ::vendor::openfde::task::V1_0::IOpenfdeTask;
 
@@ -98,6 +101,23 @@ struct handleExt {
 };
 
 struct window;
+
+struct output {
+    struct wl_output *wl_output;
+    struct zxdg_output_v1 *xdg_output;
+    int32_t logical_x, logical_y;
+    int32_t logical_width, logical_height;
+    int32_t scale;
+    char *name;
+    char *description;
+    int32_t phys_width_mm;   // Physical width (mm)
+    int32_t phys_height_mm;  // Physical height (mm)
+    int32_t pixel_width;     // pixel width (physical pixel resolution) of the current mode.
+    int32_t pixel_height;    // Pixel height (physical pixel resolution) of the current mode.
+    int done;
+    int32_t refresh;
+};
+
 
 struct display {
     struct wl_display *display;
@@ -184,6 +204,14 @@ struct display {
     bool ctrl_key_pressed;
     wl_fixed_t gesture_scale;
     bool axis_simulation_two_finger_started;
+
+    bool multi_windows;
+    bool preferred_scale;
+    struct zxdg_output_manager_v1 *xdg_output_manager;
+    struct zxdg_output_v1 *xdg_output;
+    struct output outputs[MAX_OUTPUTS];
+    int num_outputs;
+    struct output *primary;
 };
 
 struct buffer {
@@ -225,6 +253,7 @@ struct window {
     std::string appID;
     std::string taskID;
     bool isActive;
+    struct wp_fractional_scale_v1 *fractional_scale;
 };
 
 typedef struct

--- a/hwcomposer/wayland-hwc.h
+++ b/hwcomposer/wayland-hwc.h
@@ -168,6 +168,7 @@ struct display {
     std::map<struct wl_surface *, struct layerFrame> layers;
     std::map<struct wl_surface *, struct window *> windows;
     std::mutex windowsMutex;
+    std::mutex cursorMutex;
     std::map<int, struct wl_surface *> touch_surfaces;
     struct wl_surface *pointer_surface;
     struct wl_surface *cursor_surface;


### PR DESCRIPTION
为wayland版本增加多屏环境中切换显示适配。
1、收集每个屏对应的wl_output信息。
2、找出左侧屏（逻辑起始x为0）或顶部屏（逻辑起始Y为0）的wl_output作为我们的默认屏。
3、在创建窗口函数中请求全屏时（调用xdg_toplevel_set_fullscreen接口）将我们选取的目标wl_output作为参数传入，即指定FDE窗口显示在左侧或顶部屏对应的wl_output上。
4、解决FDE启动后重新调整设置其所处屏幕的缩放系数，FDE窗口会自动跳变到另外一个屏显示的问题。在收到屏幕缩放系数变化的回调后重新请求设置FDE窗口显示位置，将FDE窗口重新显示在原来的左侧屏或顶部屏的wl_output上。
5、解决拔出带触摸的显示屏时，FDE闪退问题，wl_touch_events设备节点被触发删除导致。