### PR TITLE
fixed the issue of X11 and Wayland cursors syncing failed

### DIFF
--- a/hwcomposer/hwcomposer.cpp
+++ b/hwcomposer/hwcomposer.cpp
@@ -123,7 +123,7 @@ static bool update_cursor_surface(openfde_hwc_composer_device_1* pdev, hwc_layer
         pdev->display->additional_refresh_cursor_times = 0;
         erase_cursor_layer_buffer(pdev, fb_layer->handle);
     }else{
-        if(pdev->display->additional_refresh_cursor_times > 3){      //Refresh the wayland cursor three additional times
+        if(pdev->display->additional_refresh_cursor_times > 60){      //Refresh the wayland cursor three additional times
             return true;
         }else{
             erase_cursor_layer_buffer(pdev, fb_layer->handle);

--- a/hwcomposerx11/hwcomposer.cpp
+++ b/hwcomposerx11/hwcomposer.cpp
@@ -180,7 +180,7 @@ static bool update_cursor_surface(waydroid_hwc_composer_device_1* pdev, hwc_laye
         pdev->display->additional_refresh_cursor_times = 0;
         erase_cursor_layer_buffer(pdev, fb_layer->handle);
     }else{
-        if(pdev->display->additional_refresh_cursor_times > 3){      //Refresh the wayland cursor three additional times
+        if(pdev->display->additional_refresh_cursor_times > 60){      //Refresh the wayland cursor three additional times
             return true;
         }else{
             erase_cursor_layer_buffer(pdev, fb_layer->handle);


### PR DESCRIPTION
修复Android光标已正确更新，但hwc层面对旧光标buffer未清理干净导致x11光标/Wayland光标仍显示旧光标的问题