### PR TITLE
add GRALLOC_USAGE_PRIVATE_0 usage for rgb565 in mesa env

### DIFF
--- a/gralloc/gralloc_gbm.cpp
+++ b/gralloc/gralloc_gbm.cpp
@@ -340,7 +340,9 @@ static struct gbm_bo *gbm_alloc(struct gbm_device *gbm,
 
 	handle->prime_fd = gbm_bo_get_fd(bo);
 	handle->stride = gbm_bo_get_stride(bo);
-	if (handle->format == HAL_PIXEL_FORMAT_RGB_565 && flag_is_mesa_env) {
+	if ((handle->usage & GRALLOC_USAGE_PRIVATE_0)
+			&& handle->format == HAL_PIXEL_FORMAT_RGB_565
+			&& flag_is_mesa_env) {
 		handle->stride = handle->width * gralloc_gbm_get_bpp(handle->format);
 	}
 


### PR DESCRIPTION
解决爱奇艺播放视频时偶现花屏的问题
-- 爱奇艺视频使用RGB565格式，之前使用YV12格式转RGB565时，要求对rgb进行256位对齐，而stride要求使用原始width*2，否则合成后显示会异常，爱奇艺解码数据无需转换，故stride无需处理
-- 在YV12转RGB565函数中，对RGB565格式新增GRALLOC_USAGE_PRIVATE_0的usage，gbm对该标志位做甄别处理